### PR TITLE
bug/fix-unicode

### DIFF
--- a/9 - Critical Sub-Systems/9b - Aspirations.txt
+++ b/9 - Critical Sub-Systems/9b - Aspirations.txt
@@ -4,7 +4,7 @@
 Thenomain : +jhelp bconfig3
   MYJOBS: Determines whether or not +myjobs can access the bucket. Valid
           <values> are 'yes' and 'no'.
-You say, “So :: +bucket/set <bucket>/myjobs=yes”
+You say, "So :: +bucket/set <bucket>/myjobs=yes"
 
 train +bucket/create ASP=For pitched and fulfilled aspirations. Snakes also.
 train +bucket/set ASP/myjobs=yes

--- a/9 - Critical Sub-Systems/9e - Alt Registration.txt
+++ b/9 - Critical Sub-Systems/9e - Alt Registration.txt
@@ -18,8 +18,8 @@ alt/accept <code>:
 
 
 
-You paged Trixie with ‘Like, say 'xp/convert vera=3' and it will move 3 Player XP to my 3 Normal XP?’
-You paged Trixie with ‘Because that would be AWESOME.’
+You paged Trixie with "Like, say 'xp/convert vera=3' and it will move 3 Player XP to my 3 Normal XP?"
+You paged Trixie with "Because that would be AWESOME."
 
 
 
@@ -31,7 +31,7 @@ think iter( lnum( 6 ), pack( rand( 0, 35 )), , @@ )
 
 
 "Or I could maximize pack() and make each digit rand( 0, 63 )
-You say, “I would have to be very careful to use strmatch(), tho, as it's case-sensitive.”
+You say, "I would have to be very careful to use strmatch(), tho, as it's case-sensitive."
 
 think iter( lnum( 6 ), pack( rand( 0, 63 )), , @@ )
 


### PR DESCRIPTION
Replaces smart quotes in select files with normal quotes. Makes it easier to parse with things like Python scripts.